### PR TITLE
Fix redundancy with high privilege commands

### DIFF
--- a/kernel/README
+++ b/kernel/README
@@ -13,14 +13,14 @@ Building dkms packages
 - Add your username (replace XXXXXX with your account) to the sudo list so that
   you do not have to type the password when building the package
 
-# sudo visudo
+# visudo
 XXXXXX ALL=NOPASSWD: /usr/bin/make
 
 - As standard user (no sudo) do 
 # configure
 
 - Ubuntu
-# sudo make -f Makefile.dkms deb
+# make -f Makefile.dkms deb
 
 - CentoOS/Fedora/RedHat
-# sudo make -f Makefile.dkms rpm
+# make -f Makefile.dkms rpm


### PR DESCRIPTION
When we type # it is understood that the execution of the command is done with elevated privileges. There is no need to add sudo.